### PR TITLE
Add an input option to specify the instantaneous history tap

### DIFF
--- a/ChemDyg_example_script.cfg
+++ b/ChemDyg_example_script.cfg
@@ -67,6 +67,7 @@ years = "1985:1999:15",
   [[ts_diags]]
   partition = compute
   walltime = "01:30:00"
+  input_files = "eam.h1"
   years = "1985:1986:2", # no more than 5 years
 
   [[climo_diags]]  #need preprocessing data from "native_aave"
@@ -106,10 +107,12 @@ years = "1985:1999:15",
 
   [[STE_flux_native]]
   grid = 'native'
+  input_files = "eam.h1"
   years = "1985:1999:15",
 
   [[summary_table_native]]
   grid = 'native'
+  input_files = "eam.h1"
   years = "1985:1999:15",
 
   [[pres_lat_plots]] #need preprocessing data from "180x360_aave"

--- a/templates/STE_flux_diags.bash
+++ b/templates/STE_flux_diags.bash
@@ -49,6 +49,7 @@ mkdir -p ts
 #cd ..
 # Create symbolic links to input files
 input={{ input }}/{{ input_subdir }}
+eamfile={{ input_files }}
 for (( year=${y1}; year<=${y2}; year++ ))
 do
   YYYY=`printf "%04d" ${year}`
@@ -56,7 +57,7 @@ do
   do
     ln -s ${file} ./ts
   done
-  for file in ${input}/${case}.eam.h1.${YYYY}-*.nc
+  for file in ${input}/${case}.eam.${eamfile}.${YYYY}-*.nc
   do
     ln -s ${file} ./ts
   done
@@ -114,7 +115,7 @@ endyear = ${y2}
 nyears = endyear - startyear + 1
 
 filename = short_name+'.eam.h0.*.nc'
-filenameh1 = short_name+'.eam.h1.*.nc'
+filenameh1 = short_name+'.eam.${eamfile}.*.nc'
 
 varname = ["O3"]
 

--- a/templates/chem_summary_table.bash
+++ b/templates/chem_summary_table.bash
@@ -49,6 +49,7 @@ mkdir -p ts
 #cd ..
 # Create symbolic links to input files
 input={{ input }}/{{ input_subdir }}
+eamfile={{ input_files }}
 for (( year=${y1}; year<=${y2}; year++ ))
 do
   YYYY=`printf "%04d" ${year}`
@@ -56,7 +57,7 @@ do
   do
     ln -s ${file} ./ts
   done
-  for file in ${input}/${case}.eam.h1.${YYYY}-*.nc
+  for file in ${input}/${case}.eam.${eamfile}.${YYYY}-*.nc
   do
     ln -s ${file} ./ts
   done
@@ -112,7 +113,7 @@ startyear = '${y1}'
 endyear = '${y2}'
 
 filename = short_name+'.eam.h0.*.nc'
-filenameh1 = short_name+'.eam.h1.*.nc'
+filenameh1 = short_name+'.eam.${eamfile}.*.nc'
 
 varname = ["O3","CO","CH4","NO"]
 layer = ['']

--- a/templates/e3sm_chem_diags_ts.bash
+++ b/templates/e3sm_chem_diags_ts.bash
@@ -50,6 +50,7 @@ cd ${workdir}
 #cd ..
 # Create symbolic links to input files
 input={{ input }}/{{ input_subdir }}
+eamfile={{ input_files }}
 for (( year=${y1}; year<=${y2}; year++ ))
 do
   YYYY=`printf "%04d" ${year}`
@@ -57,7 +58,7 @@ do
   do
     ln -s ${file} .
   done
-  for file in ${input}/${case}.eam.h1.${YYYY}-*.nc
+  for file in ${input}/${case}.eam.${eamfile}.${YYYY}-*.nc
   do
     ln -s ${file} .
   done
@@ -113,7 +114,7 @@ startyear = '${y1}'
 endyear = '${y2}'
 
 filename = short_name+'.eam.h0.*.nc'
-filenameh1 = short_name+'.eam.h1.*.nc'
+filenameh1 = short_name+'.eam.${eamfile}.*.nc'
 
 varname = ["O3","OH","HO2","H2O2","CH2O","CH3O2","CH3OOH","NO","NO2","NO3","N2O5",
            "HNO3","HO2NO2","PAN","CO","C2H6","C3H8","C2H4","ROHO2","CH3COCH3","C2H5O2",


### PR DESCRIPTION
In case the monthly instantaneous output was not written in the h1 file, the user can indicate the filename in the .cfg namelist. 