### PR TITLE
skip NOAA CO plot when simulation period does not match obs.

### DIFF
--- a/ChemDyg_example_script.cfg
+++ b/ChemDyg_example_script.cfg
@@ -6,7 +6,7 @@ case = 20230221.F20TR.NGD_v3atm_v2.1oi_alt
 www = /lcrc/group/e3sm/public_html/diagnostic_output/ac.lee1061
 partition = compute
 e3sm_unified = latest
-plugins = "/home/ac.lee1061/zppy_code/ChemDyg/e3sm_chem_diags.py",
+plugins = "chemdyg",
 
 [climo]
 active = True

--- a/chemdyg/templates/chemdyg_noaa_co_comparison.bash
+++ b/chemdyg/templates/chemdyg_noaa_co_comparison.bash
@@ -203,6 +203,8 @@ for n in range(len(Sta)):
 
     nmonth = np.arange(0,len(CO_sel_1D),1)
     mask = ~np.isnan(CO_sel_1D)
+    if (len(nmonth[mask]) == 0):
+        continue
     slope_e3sm, intercept, r_value, p_value, std_err = linregress(nmonth[mask], CO_sel_1D[mask])
     lin_e3sm = nmonth*slope_e3sm+intercept
     lin_e3sm_xa = xr.DataArray(lin_e3sm, coords=[time_range_noaa], dims=["time"])


### PR DESCRIPTION
Add an 'if' statement to skip the comparison plot if E3SM simulation time period does not match NOAA observation 