### PR TITLE
Make www files world-readable

### DIFF
--- a/chemdyg/templates/chemdyg_STE_flux_diags.bash
+++ b/chemdyg/templates/chemdyg_STE_flux_diags.bash
@@ -293,6 +293,10 @@ fi
 
 # Copy files
 mv *.png ${www}/${case}/e3sm_chem_diags/plots/
+
+# Change file permissions
+chmod -R go+rX,go-w ${www}/${case}/e3sm_chem_diags/plots/
+
 if [ $? != 0 ]; then
   cd ..
   echo 'ERROR (3)' > {{ prefix }}.status

--- a/chemdyg/templates/chemdyg_TOZ_eq_plot.bash
+++ b/chemdyg/templates/chemdyg_TOZ_eq_plot.bash
@@ -206,6 +206,9 @@ if [ -d "${f}" ]; then
    mv ./*.png ${www}/${case}/e3sm_chem_diags/plots/
 fi
 
+# Change file permissions
+chmod -R go+rX,go-w ${www}/${case}/e3sm_chem_diags/plots/
+
 if [ $? != 0 ]; then
   cd ..
   echo 'ERROR (2)' > {{ prefix }}.status

--- a/chemdyg/templates/chemdyg_cmip_comparison.bash
+++ b/chemdyg/templates/chemdyg_cmip_comparison.bash
@@ -233,6 +233,10 @@ fi
 
 # Copy files
 mv *.png ${www}/${case}/e3sm_chem_diags/plots/
+
+# Change file permissions
+chmod -R go+rX,go-w ${www}/${case}/e3sm_chem_diags/plots/
+
 if [ $? != 0 ]; then
   cd ..
   echo 'ERROR (3)' > {{ prefix }}.status

--- a/chemdyg/templates/chemdyg_diags.bash
+++ b/chemdyg/templates/chemdyg_diags.bash
@@ -419,6 +419,10 @@ fi
 # Copy files
 cp *.html ${www}/${case}/e3sm_chem_diags/plots/
 cp *.txt ${www}/${case}/e3sm_chem_diags/plots/
+
+# Change file permissions
+chmod -R go+rX,go-w ${www}/${case}/e3sm_chem_diags/plots/
+
 if [ $? != 0 ]; then
   cd ..
   echo 'ERROR (3)' > {{ prefix }}.status

--- a/chemdyg/templates/chemdyg_index.bash
+++ b/chemdyg/templates/chemdyg_index.bash
@@ -175,6 +175,10 @@ fi
 
 # Copy files
 cp index.html ${www}/${case}/e3sm_chem_diags/plots/
+
+# Change file permissions
+chmod -R go+rX,go-w ${www}/${case}/e3sm_chem_diags/plots/
+
 if [ $? != 0 ]; then
   cd ..
   echo 'ERROR (3)' > {{ prefix }}.status

--- a/chemdyg/templates/chemdyg_lat_lon_plots.bash
+++ b/chemdyg/templates/chemdyg_lat_lon_plots.bash
@@ -168,6 +168,10 @@ fi
 
 # Copy files
 mv *.png ${www}/${case}/e3sm_chem_diags/plots/
+
+# Change file permissions
+chmod -R go+rX,go-w ${www}/${case}/e3sm_chem_diags/plots/
+
 if [ $? != 0 ]; then
   cd ..
   echo 'ERROR (3)' > {{ prefix }}.status

--- a/chemdyg/templates/chemdyg_noaa_co_comparison.bash
+++ b/chemdyg/templates/chemdyg_noaa_co_comparison.bash
@@ -257,6 +257,10 @@ fi
 
 # Copy files
 mv *.png ${www}/${case}/e3sm_chem_diags/plots/
+
+# Change file permissions
+chmod -R go+rX,go-w ${www}/${case}/e3sm_chem_diags/plots/
+
 if [ $? != 0 ]; then
   cd ..
   echo 'ERROR (3)' > {{ prefix }}.status

--- a/chemdyg/templates/chemdyg_nox_emis_plots.bash
+++ b/chemdyg/templates/chemdyg_nox_emis_plots.bash
@@ -215,6 +215,10 @@ fi
 
 # Copy files
 mv *.png ${www}/${case}/e3sm_chem_diags/plots/
+
+# Change file permissions
+chmod -R go+rX,go-w ${www}/${case}/e3sm_chem_diags/plots/
+
 if [ $? != 0 ]; then
   cd ..
   echo 'ERROR (3)' > {{ prefix }}.status

--- a/chemdyg/templates/chemdyg_o3_hole_diags.bash
+++ b/chemdyg/templates/chemdyg_o3_hole_diags.bash
@@ -227,6 +227,9 @@ if [ -d "${f}" ]; then
    mv ./*.png ${www}/${case}/e3sm_chem_diags/plots/
 fi
 
+# Change file permissions
+chmod -R go+rX,go-w ${www}/${case}/e3sm_chem_diags/plots/
+
 if [ $? != 0 ]; then
   cd ..
   echo 'ERROR (2)' > {{ prefix }}.status

--- a/chemdyg/templates/chemdyg_pres_lat_plots.bash
+++ b/chemdyg/templates/chemdyg_pres_lat_plots.bash
@@ -470,6 +470,10 @@ fi
 
 # Copy files
 mv *.png ${www}/${case}/e3sm_chem_diags/plots/
+
+# Change file permissions
+chmod -R go+rX,go-w ${www}/${case}/e3sm_chem_diags/plots/
+
 if [ $? != 0 ]; then
   cd ..
   echo 'ERROR (3)' > {{ prefix }}.status

--- a/chemdyg/templates/chemdyg_summary_table.bash
+++ b/chemdyg/templates/chemdyg_summary_table.bash
@@ -352,6 +352,10 @@ fi
 
 # Copy files
 mv *.html ${www}/${case}/e3sm_chem_diags/plots/
+
+# Change file permissions
+chmod -R go+rX,go-w ${www}/${case}/e3sm_chem_diags/plots/
+
 if [ $? != 0 ]; then
   cd ..
   echo 'ERROR (3)' > {{ prefix }}.status

--- a/chemdyg/templates/chemdyg_surf_o3_diags.bash
+++ b/chemdyg/templates/chemdyg_surf_o3_diags.bash
@@ -778,6 +778,9 @@ if [ -d "${f}" ]; then
    mv ./*.png ${www}/${case}/e3sm_chem_diags/plots/
 fi
 
+# Change file permissions
+chmod -R go+rX,go-w ${www}/${case}/e3sm_chem_diags/plots/
+
 if [ $? != 0 ]; then
   cd ..
   echo 'ERROR (2)' > {{ prefix }}.status

--- a/chemdyg/templates/chemdyg_temperature_eq_plot.bash
+++ b/chemdyg/templates/chemdyg_temperature_eq_plot.bash
@@ -226,6 +226,9 @@ if [ -d "${f}" ]; then
    mv ./*.png ${www}/${case}/e3sm_chem_diags/plots/
 fi
 
+# Change file permissions
+chmod -R go+rX,go-w ${www}/${case}/e3sm_chem_diags/plots/
+
 if [ $? != 0 ]; then
   cd ..
   echo 'ERROR (2)' > {{ prefix }}.status

--- a/chemdyg/templates/chemdyg_ts.bash
+++ b/chemdyg/templates/chemdyg_ts.bash
@@ -284,6 +284,10 @@ fi
 # Copy files
 cp *.html ${www}/${case}/e3sm_chem_diags/plots/
 cp *.txt ${www}/${case}/e3sm_chem_diags/plots/
+
+# Change file permissions
+chmod -R go+rX,go-w ${www}/${case}/e3sm_chem_diags/plots/
+
 if [ $? != 0 ]; then
   cd ..
   echo 'ERROR (3)' > {{ prefix }}.status


### PR DESCRIPTION
The files under ${www}/${case}/e3sm_chem_diags/plots/ are not world-readable. It is a pain to manually change file permissions after every ChemDyg job.

This commit makes the files under the www directory world-readable.