### PR TITLE
Fix file names for non-AMIP (F1850/F2010) runs

### DIFF
--- a/chemdyg/templates/chemdyg_TOZ_eq_plot.bash
+++ b/chemdyg/templates/chemdyg_TOZ_eq_plot.bash
@@ -66,7 +66,7 @@ do
   done
 done
 
-ln -s ${input}/${case}.eam.h0.${y1}-01.nc ./ts
+ln -s ${input}/${case}.eam.h0.${Y1}-01.nc ./ts
 
 {%- if frequency != 'monthly' %}
 # For non-monthly input files, need to add the last file of the previous year

--- a/chemdyg/templates/chemdyg_o3_hole_diags.bash
+++ b/chemdyg/templates/chemdyg_o3_hole_diags.bash
@@ -70,7 +70,7 @@ do
   done
 done
 
-ln -s ${input}/${case}.eam.h0.${y1}-01.nc ./ts
+ln -s ${input}/${case}.eam.h0.${Y1}-01.nc ./ts
 
 {%- if frequency != 'monthly' %}
 # For non-monthly input files, need to add the last file of the previous year

--- a/chemdyg/templates/chemdyg_temperature_eq_plot.bash
+++ b/chemdyg/templates/chemdyg_temperature_eq_plot.bash
@@ -66,7 +66,7 @@ do
   done
 done
 
-ln -s ${input}/${case}.eam.h0.${y1}-01.nc ./ts
+ln -s ${input}/${case}.eam.h0.${Y1}-01.nc ./ts
 
 #{%- if frequency != 'monthly' %}
 ## For non-monthly input files, need to add the last file of the previous year


### PR DESCRIPTION
Fixes the broken symbolic links for eam.h0 files of plots like ozone hole.