### PR TITLE
Fix o3_hole_diags when not starting from the beginning of a simulation

### DIFF
--- a/chemdyg/templates/chemdyg_o3_hole_diags.bash
+++ b/chemdyg/templates/chemdyg_o3_hole_diags.bash
@@ -148,7 +148,7 @@ endindex = startindex + years*365
 
 O3_area = TOZ_min.copy()
 
-for i in range(startindex,endindex):
+for i in range(startindex,t_period):
     d = {'TOZ': np.array(TOZ_sel[i]), 'AREA': np.array(AREA_sel[0])}
     df = pd.DataFrame(data=d)
 


### PR DESCRIPTION
Solves #23 for `O3hole_diags_columns.py`, but not for `TOZ_eq_plot.py`, which will be fixed in a future PR.