### PR TITLE
Add year string in the chemdyg directory names

### DIFF
--- a/chemdyg/main.py
+++ b/chemdyg/main.py
@@ -92,7 +92,7 @@ def chemdyg(path, config, scriptDir, existing_bundles, job_ids_file):
                 prefix = 'chemdyg_%s_%04d-%04d' % (sub,c['year1'],c['year2'])
                 template = templateEnv.get_template( 'chemdyg_nox_emis_plots.bash' )
             elif c['subsection'] == "index":
-                prefix = 'chemdyg_index'
+                prefix = 'chemdyg_index_%04d-%04d' % (c['year1'],c['year2'])
                 template = templateEnv.get_template( 'chemdyg_index.bash' )
             else:
                 sub = c['grid']

--- a/chemdyg/templates/chemdyg_STE_flux_diags.bash
+++ b/chemdyg/templates/chemdyg_STE_flux_diags.bash
@@ -283,7 +283,9 @@ echo ===== COPY FILES TO WEB SERVER =====
 echo
 
 # Create top-level directory
-f=${www}/${case}/e3sm_chem_diags/plots/
+tmp_Y1=`printf "%04d" ${y1}`
+tmp_Y2=`printf "%04d" ${y2}`
+f=${www}/${case}/e3sm_chem_diags_${tmp_Y1}_${tmp_Y2}/plots/
 mkdir -p ${f}
 if [ $? != 0 ]; then
   cd ..
@@ -292,10 +294,10 @@ if [ $? != 0 ]; then
 fi
 
 # Copy files
-mv *.png ${www}/${case}/e3sm_chem_diags/plots/
+mv *.png ${f}
 
 # Change file permissions
-chmod -R go+rX,go-w ${www}/${case}/e3sm_chem_diags/plots/
+chmod -R go+rX,go-w ${f}
 
 if [ $? != 0 ]; then
   cd ..

--- a/chemdyg/templates/chemdyg_TOZ_eq_plot.bash
+++ b/chemdyg/templates/chemdyg_TOZ_eq_plot.bash
@@ -202,13 +202,14 @@ echo ===== COPY FILES TO WEB SERVER =====
 echo
 
 # Create top-level directory
-f=${www}/${case}/e3sm_chem_diags/plots/
+f=${www}/${case}/e3sm_chem_diags_${Y1}_${Y2}/plots/
+mkdir -p ${f}
 if [ -d "${f}" ]; then
-   mv ./*.png ${www}/${case}/e3sm_chem_diags/plots/
+   mv ./*.png ${f}
 fi
 
 # Change file permissions
-chmod -R go+rX,go-w ${www}/${case}/e3sm_chem_diags/plots/
+chmod -R go+rX,go-w ${f}
 
 if [ $? != 0 ]; then
   cd ..

--- a/chemdyg/templates/chemdyg_cmip_comparison.bash
+++ b/chemdyg/templates/chemdyg_cmip_comparison.bash
@@ -223,7 +223,7 @@ echo ===== COPY FILES TO WEB SERVER =====
 echo
 
 # Create top-level directory
-f=${www}/${case}/e3sm_chem_diags/plots/
+f=${www}/${case}/e3sm_chem_diags_${Y1}_${Y2}/plots/
 mkdir -p ${f}
 if [ $? != 0 ]; then
   cd ..
@@ -232,10 +232,10 @@ if [ $? != 0 ]; then
 fi
 
 # Copy files
-mv *.png ${www}/${case}/e3sm_chem_diags/plots/
+mv *.png ${f}
 
 # Change file permissions
-chmod -R go+rX,go-w ${www}/${case}/e3sm_chem_diags/plots/
+chmod -R go+rX,go-w ${f}
 
 if [ $? != 0 ]; then
   cd ..

--- a/chemdyg/templates/chemdyg_diags.bash
+++ b/chemdyg/templates/chemdyg_diags.bash
@@ -408,7 +408,7 @@ echo ===== COPY FILES TO WEB SERVER =====
 echo
 
 # Create top-level directory
-f=${www}/${case}/e3sm_chem_diags/plots/
+f=${www}/${case}/e3sm_chem_diags_${Y1}_${Y2}/plots/
 mkdir -p ${f}
 if [ $? != 0 ]; then
   cd ..
@@ -417,11 +417,11 @@ if [ $? != 0 ]; then
 fi
 
 # Copy files
-cp *.html ${www}/${case}/e3sm_chem_diags/plots/
-cp *.txt ${www}/${case}/e3sm_chem_diags/plots/
+cp *.html ${f}
+cp *.txt ${f}
 
 # Change file permissions
-chmod -R go+rX,go-w ${www}/${case}/e3sm_chem_diags/plots/
+chmod -R go+rX,go-w ${f}
 
 if [ $? != 0 ]; then
   cd ..

--- a/chemdyg/templates/chemdyg_index.bash
+++ b/chemdyg/templates/chemdyg_index.bash
@@ -165,7 +165,7 @@ echo ===== COPY FILES TO WEB SERVER =====
 echo
 
 # Create top-level directory
-f=${www}/${case}/e3sm_chem_diags/plots/
+f=${www}/${case}/e3sm_chem_diags_${Y1}_${Y2}/plots/
 mkdir -p ${f}
 if [ $? != 0 ]; then
   cd ..
@@ -174,10 +174,10 @@ if [ $? != 0 ]; then
 fi
 
 # Copy files
-cp index.html ${www}/${case}/e3sm_chem_diags/plots/
+cp index.html ${f}
 
 # Change file permissions
-chmod -R go+rX,go-w ${www}/${case}/e3sm_chem_diags/plots/
+chmod -R go+rX,go-w ${f}
 
 if [ $? != 0 ]; then
   cd ..

--- a/chemdyg/templates/chemdyg_lat_lon_plots.bash
+++ b/chemdyg/templates/chemdyg_lat_lon_plots.bash
@@ -158,7 +158,7 @@ echo ===== COPY FILES TO WEB SERVER =====
 echo
 
 # Create top-level directory
-f=${www}/${case}/e3sm_chem_diags/plots/
+f=${www}/${case}/e3sm_chem_diags_${Y1}_${Y2}/plots/
 mkdir -p ${f}
 if [ $? != 0 ]; then
   cd ..
@@ -167,10 +167,10 @@ if [ $? != 0 ]; then
 fi
 
 # Copy files
-mv *.png ${www}/${case}/e3sm_chem_diags/plots/
+mv *.png ${f}
 
 # Change file permissions
-chmod -R go+rX,go-w ${www}/${case}/e3sm_chem_diags/plots/
+chmod -R go+rX,go-w ${f}
 
 if [ $? != 0 ]; then
   cd ..

--- a/chemdyg/templates/chemdyg_noaa_co_comparison.bash
+++ b/chemdyg/templates/chemdyg_noaa_co_comparison.bash
@@ -247,7 +247,7 @@ echo ===== COPY FILES TO WEB SERVER =====
 echo
 
 # Create top-level directory
-f=${www}/${case}/e3sm_chem_diags/plots/
+f=${www}/${case}/e3sm_chem_diags_${Y1}_${Y2}/plots/
 mkdir -p ${f}
 if [ $? != 0 ]; then
   cd ..
@@ -256,10 +256,10 @@ if [ $? != 0 ]; then
 fi
 
 # Copy files
-mv *.png ${www}/${case}/e3sm_chem_diags/plots/
+mv *.png ${f}
 
 # Change file permissions
-chmod -R go+rX,go-w ${www}/${case}/e3sm_chem_diags/plots/
+chmod -R go+rX,go-w ${f}
 
 if [ $? != 0 ]; then
   cd ..

--- a/chemdyg/templates/chemdyg_nox_emis_plots.bash
+++ b/chemdyg/templates/chemdyg_nox_emis_plots.bash
@@ -205,7 +205,7 @@ echo ===== COPY FILES TO WEB SERVER =====
 echo
 
 # Create top-level directory
-f=${www}/${case}/e3sm_chem_diags/plots/
+f=${www}/${case}/e3sm_chem_diags_${Y1}_${Y2}/plots/
 mkdir -p ${f}
 if [ $? != 0 ]; then
   cd ..
@@ -214,10 +214,10 @@ if [ $? != 0 ]; then
 fi
 
 # Copy files
-mv *.png ${www}/${case}/e3sm_chem_diags/plots/
+mv *.png ${f}
 
 # Change file permissions
-chmod -R go+rX,go-w ${www}/${case}/e3sm_chem_diags/plots/
+chmod -R go+rX,go-w ${f}
 
 if [ $? != 0 ]; then
   cd ..

--- a/chemdyg/templates/chemdyg_o3_hole_diags.bash
+++ b/chemdyg/templates/chemdyg_o3_hole_diags.bash
@@ -219,13 +219,14 @@ echo ===== COPY FILES TO WEB SERVER =====
 echo
 
 # Create top-level directory
-f=${www}/${case}/e3sm_chem_diags/plots/
+f=${www}/${case}/e3sm_chem_diags_${Y1}_${Y2}/plots/
+mkdir -p ${f}
 if [ -d "${f}" ]; then
-   mv ./*.png ${www}/${case}/e3sm_chem_diags/plots/
+   mv ./*.png ${f}
 fi
 
 # Change file permissions
-chmod -R go+rX,go-w ${www}/${case}/e3sm_chem_diags/plots/
+chmod -R go+rX,go-w ${f}
 
 if [ $? != 0 ]; then
   cd ..

--- a/chemdyg/templates/chemdyg_pres_lat_plots.bash
+++ b/chemdyg/templates/chemdyg_pres_lat_plots.bash
@@ -460,7 +460,7 @@ echo ===== COPY FILES TO WEB SERVER =====
 echo
 
 # Create top-level directory
-f=${www}/${case}/e3sm_chem_diags/plots/
+f=${www}/${case}/e3sm_chem_diags_${Y1}_${Y2}/plots/
 mkdir -p ${f}
 if [ $? != 0 ]; then
   cd ..
@@ -469,10 +469,10 @@ if [ $? != 0 ]; then
 fi
 
 # Copy files
-mv *.png ${www}/${case}/e3sm_chem_diags/plots/
+mv *.png ${f}
 
 # Change file permissions
-chmod -R go+rX,go-w ${www}/${case}/e3sm_chem_diags/plots/
+chmod -R go+rX,go-w ${f}
 
 if [ $? != 0 ]; then
   cd ..

--- a/chemdyg/templates/chemdyg_summary_table.bash
+++ b/chemdyg/templates/chemdyg_summary_table.bash
@@ -340,7 +340,9 @@ echo ===== COPY FILES TO WEB SERVER =====
 echo
 
 # Create top-level directory
-f=${www}/${case}/e3sm_chem_diags/plots/
+tmp_Y1=`printf "%04d" ${y1}`
+tmp_Y2=`printf "%04d" ${y2}`
+f=${www}/${case}/e3sm_chem_diags_${tmp_Y1}_${tmp_Y2}/plots/
 mkdir -p ${f}
 if [ $? != 0 ]; then
   cd ..
@@ -349,10 +351,10 @@ if [ $? != 0 ]; then
 fi
 
 # Copy files
-mv *.html ${www}/${case}/e3sm_chem_diags/plots/
+mv *.html ${f}
 
 # Change file permissions
-chmod -R go+rX,go-w ${www}/${case}/e3sm_chem_diags/plots/
+chmod -R go+rX,go-w ${f}
 
 if [ $? != 0 ]; then
   cd ..

--- a/chemdyg/templates/chemdyg_surf_o3_diags.bash
+++ b/chemdyg/templates/chemdyg_surf_o3_diags.bash
@@ -773,13 +773,14 @@ echo ===== COPY FILES TO WEB SERVER =====
 echo
 
 # Create top-level directory
-f=${www}/${case}/e3sm_chem_diags/plots/
+f=${www}/${case}/e3sm_chem_diags_${Y1}_${Y2}/plots/
+mkdir -p ${f}
 if [ -d "${f}" ]; then
-   mv ./*.png ${www}/${case}/e3sm_chem_diags/plots/
+   mv ./*.png ${f}
 fi
 
 # Change file permissions
-chmod -R go+rX,go-w ${www}/${case}/e3sm_chem_diags/plots/
+chmod -R go+rX,go-w ${f}
 
 if [ $? != 0 ]; then
   cd ..

--- a/chemdyg/templates/chemdyg_temperature_eq_plot.bash
+++ b/chemdyg/templates/chemdyg_temperature_eq_plot.bash
@@ -221,13 +221,14 @@ echo ===== COPY FILES TO WEB SERVER =====
 echo
 
 # Create top-level directory
-f=${www}/${case}/e3sm_chem_diags/plots/
+f=${www}/${case}/e3sm_chem_diags_${Y1}_${Y2}/plots/
+mkdir -p ${f}
 if [ -d "${f}" ]; then
-   mv ./*.png ${www}/${case}/e3sm_chem_diags/plots/
+   mv ./*.png ${f}
 fi
 
 # Change file permissions
-chmod -R go+rX,go-w ${www}/${case}/e3sm_chem_diags/plots/
+chmod -R go+rX,go-w ${f}
 
 if [ $? != 0 ]; then
   cd ..

--- a/chemdyg/templates/chemdyg_ts.bash
+++ b/chemdyg/templates/chemdyg_ts.bash
@@ -273,7 +273,9 @@ echo ===== COPY FILES TO WEB SERVER =====
 echo
 
 # Create top-level directory
-f=${www}/${case}/e3sm_chem_diags/plots/
+tmp_Y1=`printf "%04d" ${y1}`
+tmp_Y2=`printf "%04d" ${y2}`
+f=${www}/${case}/e3sm_chem_diags_${tmp_Y1}_${tmp_Y2}/plots/
 mkdir -p ${f}
 if [ $? != 0 ]; then
   cd ..
@@ -282,11 +284,11 @@ if [ $? != 0 ]; then
 fi
 
 # Copy files
-cp *.html ${www}/${case}/e3sm_chem_diags/plots/
-cp *.txt ${www}/${case}/e3sm_chem_diags/plots/
+cp *.html ${f}
+cp *.txt ${f}
 
 # Change file permissions
-chmod -R go+rX,go-w ${www}/${case}/e3sm_chem_diags/plots/
+chmod -R go+rX,go-w ${f}
 
 if [ $? != 0 ]; then
   cd ..


### PR DESCRIPTION
It is required to run chemdyg multiple times for different time periods of a long simulation. This is not possible because the www directory name doesn't have different names for different periods. This commit adds the year string in the directory names corresponding to different periods.

An example output can be found at: https://web.lcrc.anl.gov/public/e3sm/diagnostic_output/ac.qtang/E3SMv3_dev/20230622.v3alpha02.piControl.chrysalis/