### PR TITLE
Fixes for zppy 3.0.0

### DIFF
--- a/chemdyg/__init__.py
+++ b/chemdyg/__init__.py
@@ -1,2 +1,1 @@
 from chemdyg.main import chemdyg
-

--- a/chemdyg/main.py
+++ b/chemdyg/main.py
@@ -3,12 +3,11 @@ import os
 import pprint
 
 from zppy.utils import (
-    checkStatus,
-    getComponent,
-    getTasks,
-    getYears,
-    makeExecutable,
-    submitScript,
+    check_status,
+    get_tasks,
+    get_years,
+    make_executable,
+    submit_script,
 )
 
 # -----------------------------------------------------------------------------
@@ -22,7 +21,7 @@ def chemdyg(path, config, scriptDir, existing_bundles, job_ids_file):
     templateEnv = jinja2.Environment( loader=templateLoader )
 
     # --- List of chemdyg tasks ---
-    tasks = getTasks(config, 'chemdyg')
+    tasks = get_tasks(config, 'chemdyg')
     if (len(tasks) == 0):
         return existing_bundles
 
@@ -37,7 +36,7 @@ def chemdyg(path, config, scriptDir, existing_bundles, job_ids_file):
          # c['component2'] = getComponent(c['input_files2'])
 
         # Loop over year sets
-        year_sets = getYears(c['years'])
+        year_sets = get_years(c['years'])
         for s in year_sets:
             c['year1'] = s[0]
             c['year2'] = s[1]
@@ -107,14 +106,14 @@ def chemdyg(path, config, scriptDir, existing_bundles, job_ids_file):
             scriptFile = os.path.join(scriptDir, '%s.bash' % (prefix))
             statusFile = os.path.join(scriptDir, '%s.status' % (prefix))
             settingsFile = os.path.join(scriptDir, "%s.settings" % (prefix))
-            skip = checkStatus(statusFile)
+            skip = check_status(statusFile)
             if skip:
                 continue
 
             # Create script
             with open(scriptFile, 'w') as f:
                 f.write(template.render( **c ))
-            makeExecutable(scriptFile)
+            make_executable(scriptFile)
 
             with open(settingsFile, "w") as sf:
                 p = pprint.PrettyPrinter(indent=2, stream=sf)
@@ -131,7 +130,7 @@ def chemdyg(path, config, scriptDir, existing_bundles, job_ids_file):
             elif c['subsection'] == "QBO_diags":
                 dependencies = [ os.path.join(scriptDir, 'ts_atm_monthly_180x360_aave_%04d-%04d-%04d.status' % (c['year1'],c['year2'],c['ypf'])), ]
             elif c['subsection'] == "surf_o3_diags":
-                dependencies = [ os.path.join(scriptDir, 'ts_atm_hourly_US1.0x1.0_nco_%04d-%04d-%04d.status' % (c['year1'],c['year2'],c['ypf'])), ] 
+                dependencies = [ os.path.join(scriptDir, 'ts_atm_hourly_US1.0x1.0_nco_%04d-%04d-%04d.status' % (c['year1'],c['year2'],c['ypf'])), ]
             elif c['subsection'] == "climo_diags":
                 dependencies = [ os.path.join(scriptDir, 'climo_native_aave_%04d-%04d.status' % (c['year1'],c['year2'])), ]
             elif c['subsection'] == "pres_lat_plots":
@@ -144,7 +143,7 @@ def chemdyg(path, config, scriptDir, existing_bundles, job_ids_file):
             if not c["dry_run"]:
                 if c["bundle"] == "":
                     # Submit job
-                    submitScript(scriptFile, statusFile, export, job_ids_file, dependFiles=dependencies)
+                    submit_script(scriptFile, statusFile, export, job_ids_file, dependFiles=dependencies)
                 else:
                     print("...adding to bundle '%s'" % (c["bundle"]))
 

--- a/chemdyg/main.py
+++ b/chemdyg/main.py
@@ -10,15 +10,16 @@ from zppy.utils import (
     submit_script,
 )
 
+
 # -----------------------------------------------------------------------------
 def chemdyg(path, config, scriptDir, existing_bundles, job_ids_file):
 
     # Initialize jinja2 template engine
-    path_extra = os.path.join(path,"templates")
+    path_extra = os.path.join(path, "templates")
     templateLoader = jinja2.FileSystemLoader(
         searchpath=(config["default"]["templateDir"], path_extra)
     )
-    templateEnv = jinja2.Environment( loader=templateLoader )
+    templateEnv = jinja2.Environment(loader=templateLoader)
 
     # --- List of chemdyg tasks ---
     tasks = get_tasks(config, 'chemdyg')
@@ -29,11 +30,11 @@ def chemdyg(path, config, scriptDir, existing_bundles, job_ids_file):
     for c in tasks:
 
         if 'ts_num_years' in c.keys():
-          c['ts_num_years'] = int(c['ts_num_years'])
+            c['ts_num_years'] = int(c['ts_num_years'])
 
         # Component
-         # c['component'] = getComponent(c['input_files'])
-         # c['component2'] = getComponent(c['input_files2'])
+        # c['component'] = getComponent(c['input_files'])
+        # c['component2'] = getComponent(c['input_files2'])
 
         # Loop over year sets
         year_sets = get_years(c['years'])
@@ -44,63 +45,78 @@ def chemdyg(path, config, scriptDir, existing_bundles, job_ids_file):
             c['scriptDir'] = scriptDir
             if c['subsection'] == "ts_diags":
                 sub = c['subsection']
-                prefix = 'chemdyg_%s_%04d-%04d' % (sub,c['year1'],c['year2'])
-                template = templateEnv.get_template( 'chemdyg_ts.bash' )
+                prefix = 'chemdyg_%s_%04d-%04d' % (sub, c['year1'], c['year2'])
+                template = templateEnv.get_template(
+                    'chemdyg_ts.bash')
             elif c['subsection'] == "o3_hole_diags":
                 sub = c['subsection']
-                prefix = 'chemdyg_%s_%04d-%04d' % (sub,c['year1'],c['year2'])
-                template = templateEnv.get_template( 'chemdyg_o3_hole_diags.bash' )
+                prefix = 'chemdyg_%s_%04d-%04d' % (sub, c['year1'], c['year2'])
+                template = templateEnv.get_template(
+                    'chemdyg_o3_hole_diags.bash')
             elif c['subsection'] == "TOZ_eq_native":
                 sub = c['subsection']
-                prefix = 'chemdyg_%s_%04d-%04d' % (sub,c['year1'],c['year2'])
-                template = templateEnv.get_template( 'chemdyg_TOZ_eq_plot.bash' )
+                prefix = 'chemdyg_%s_%04d-%04d' % (sub, c['year1'], c['year2'])
+                template = templateEnv.get_template(
+                    'chemdyg_TOZ_eq_plot.bash')
             elif c['subsection'] == "surf_o3_diags":
                 sub = c['subsection']
-                prefix = 'chemdyg_%s_%04d-%04d' % (sub,c['year1'],c['year2'])
-                template = templateEnv.get_template( 'chemdyg_surf_o3_diags.bash' )
+                prefix = 'chemdyg_%s_%04d-%04d' % (sub, c['year1'], c['year2'])
+                template = templateEnv.get_template(
+                    'chemdyg_surf_o3_diags.bash')
             elif c['subsection'] == "STE_flux_native":
                 sub = c['subsection']
-                prefix = 'chemdyg_%s_%04d-%04d' % (sub,c['year1'],c['year2'])
-                template = templateEnv.get_template( 'chemdyg_STE_flux_diags.bash' )
+                prefix = 'chemdyg_%s_%04d-%04d' % (sub, c['year1'], c['year2'])
+                template = templateEnv.get_template(
+                    'chemdyg_STE_flux_diags.bash')
             elif c['subsection'] == "temperature_eq_native":
                 sub = c['subsection']
-                prefix = 'chemdyg_%s_%04d-%04d' % (sub,c['year1'],c['year2'])
-                template = templateEnv.get_template( 'chemdyg_temperature_eq_plot.bash' )
+                prefix = 'chemdyg_%s_%04d-%04d' % (sub, c['year1'], c['year2'])
+                template = templateEnv.get_template(
+                    'chemdyg_temperature_eq_plot.bash')
             elif c['subsection'] == "summary_table_native":
                 sub = c['subsection']
-                prefix = 'chemdyg_%s_%04d-%04d' % (sub,c['year1'],c['year2'])
-                template = templateEnv.get_template( 'chemdyg_summary_table.bash' )
+                prefix = 'chemdyg_%s_%04d-%04d' % (sub, c['year1'], c['year2'])
+                template = templateEnv.get_template(
+                    'chemdyg_summary_table.bash')
             elif c['subsection'] == "cmip_comparison":
                 sub = c['subsection']
-                prefix = 'chemdyg_%s_%04d-%04d' % (sub,c['year1'],c['year2'])
-                template = templateEnv.get_template( 'chemdyg_cmip_comparison.bash' )
+                prefix = 'chemdyg_%s_%04d-%04d' % (sub, c['year1'], c['year2'])
+                template = templateEnv.get_template(
+                    'chemdyg_cmip_comparison.bash')
             elif c['subsection'] == "noaa_co_comparison":
                 sub = c['subsection']
-                prefix = 'chemdyg_%s_%04d-%04d' % (sub,c['year1'],c['year2'])
-                template = templateEnv.get_template( 'chemdyg_noaa_co_comparison.bash' )
+                prefix = 'chemdyg_%s_%04d-%04d' % (sub, c['year1'], c['year2'])
+                template = templateEnv.get_template(
+                    'chemdyg_noaa_co_comparison.bash')
             elif c['subsection'] == "QBO_diags":
                 sub = c['subsection']
-                prefix = 'chemdyg_%s_%04d-%04d' % (sub,c['year1'],c['year2'])
-                template = templateEnv.get_template( 'chemdyg_QBO_diags.bash' )
+                prefix = 'chemdyg_%s_%04d-%04d' % (sub, c['year1'], c['year2'])
+                template = templateEnv.get_template(
+                    'chemdyg_QBO_diags.bash')
             elif c['subsection'] == "pres_lat_plots":
                 sub = c['subsection']
-                prefix = 'chemdyg_%s_%04d-%04d' % (sub,c['year1'],c['year2'])
-                template = templateEnv.get_template( 'chemdyg_pres_lat_plots.bash' )
+                prefix = 'chemdyg_%s_%04d-%04d' % (sub, c['year1'], c['year2'])
+                template = templateEnv.get_template(
+                    'chemdyg_pres_lat_plots.bash')
             elif c['subsection'] == "lat_lon_plots":
                 sub = c['subsection']
-                prefix = 'chemdyg_%s_%04d-%04d' % (sub,c['year1'],c['year2'])
-                template = templateEnv.get_template( 'chemdyg_lat_lon_plots.bash' )
+                prefix = 'chemdyg_%s_%04d-%04d' % (sub, c['year1'], c['year2'])
+                template = templateEnv.get_template(
+                    'chemdyg_lat_lon_plots.bash')
             elif c['subsection'] == "nox_emis_plots":
                 sub = c['subsection']
-                prefix = 'chemdyg_%s_%04d-%04d' % (sub,c['year1'],c['year2'])
-                template = templateEnv.get_template( 'chemdyg_nox_emis_plots.bash' )
+                prefix = 'chemdyg_%s_%04d-%04d' % (sub, c['year1'], c['year2'])
+                template = templateEnv.get_template(
+                    'chemdyg_nox_emis_plots.bash')
             elif c['subsection'] == "index":
-                prefix = 'chemdyg_index_%04d-%04d' % (c['year1'],c['year2'])
-                template = templateEnv.get_template( 'chemdyg_index.bash' )
+                prefix = 'chemdyg_index_%04d-%04d' % (c['year1'], c['year2'])
+                template = templateEnv.get_template(
+                    'chemdyg_index.bash')
             else:
                 sub = c['grid']
-                prefix = 'chemdyg_diags_%04d-%04d' % (c['year1'],c['year2'])
-                template = templateEnv.get_template( 'chemdyg_diags.bash' )
+                prefix = 'chemdyg_diags_%04d-%04d' % (c['year1'], c['year2'])
+                template = templateEnv.get_template(
+                    'chemdyg_diags.bash')
             print(prefix)
             c['prefix'] = prefix
             scriptFile = os.path.join(scriptDir, '%s.bash' % (prefix))
@@ -112,7 +128,7 @@ def chemdyg(path, config, scriptDir, existing_bundles, job_ids_file):
 
             # Create script
             with open(scriptFile, 'w') as f:
-                f.write(template.render( **c ))
+                f.write(template.render(**c))
             make_executable(scriptFile)
 
             with open(settingsFile, "w") as sf:
@@ -124,26 +140,27 @@ def chemdyg(path, config, scriptDir, existing_bundles, job_ids_file):
             export = 'NONE'
             dependencies = []
             if c['subsection'] == "cmip_comparison":
-                dependencies = [ os.path.join(scriptDir, 'ts_atm_monthly_180x360_aave_%04d-%04d-%04d.status' % (c['year1'],c['year2'],c['ypf'])), ]
+                dependencies = [os.path.join(scriptDir, 'ts_atm_monthly_180x360_aave_%04d-%04d-%04d.status' % (c['year1'], c['year2'], c['ypf'])), ]
             elif c['subsection'] == "noaa_co_comparison":
-                dependencies = [ os.path.join(scriptDir, 'ts_atm_monthly_180x360_aave_%04d-%04d-%04d.status' % (c['year1'],c['year2'],c['ypf'])), ]
+                dependencies = [os.path.join(scriptDir, 'ts_atm_monthly_180x360_aave_%04d-%04d-%04d.status' % (c['year1'], c['year2'], c['ypf'])), ]
             elif c['subsection'] == "QBO_diags":
-                dependencies = [ os.path.join(scriptDir, 'ts_atm_monthly_180x360_aave_%04d-%04d-%04d.status' % (c['year1'],c['year2'],c['ypf'])), ]
+                dependencies = [os.path.join(scriptDir, 'ts_atm_monthly_180x360_aave_%04d-%04d-%04d.status' % (c['year1'], c['year2'], c['ypf'])), ]
             elif c['subsection'] == "surf_o3_diags":
-                dependencies = [ os.path.join(scriptDir, 'ts_atm_hourly_US1.0x1.0_nco_%04d-%04d-%04d.status' % (c['year1'],c['year2'],c['ypf'])), ]
+                dependencies = [os.path.join(scriptDir, 'ts_atm_hourly_US1.0x1.0_nco_%04d-%04d-%04d.status' % (c['year1'], c['year2'], c['ypf'])), ]
             elif c['subsection'] == "climo_diags":
-                dependencies = [ os.path.join(scriptDir, 'climo_native_aave_%04d-%04d.status' % (c['year1'],c['year2'])), ]
+                dependencies = [os.path.join(scriptDir, 'climo_native_aave_%04d-%04d.status' % (c['year1'], c['year2'])), ]
             elif c['subsection'] == "pres_lat_plots":
-                dependencies = [ os.path.join(scriptDir, 'climo_180x360_aave_%04d-%04d.status' % (c['year1'],c['year2'])), ]
+                dependencies = [os.path.join(scriptDir, 'climo_180x360_aave_%04d-%04d.status' % (c['year1'], c['year2'])), ]
             elif c['subsection'] == "lat_lon_plots":
-                dependencies = [ os.path.join(scriptDir, 'climo_180x360_aave_%04d-%04d.status' % (c['year1'],c['year2'])), ]
+                dependencies = [os.path.join(scriptDir, 'climo_180x360_aave_%04d-%04d.status' % (c['year1'], c['year2'])), ]
             elif c['subsection'] == "nox_emis_plots":
-                dependencies = [ os.path.join(scriptDir, 'climo_180x360_aave_%04d-%04d.status' % (c['year1'],c['year2'])), ]
+                dependencies = [os.path.join(scriptDir, 'climo_180x360_aave_%04d-%04d.status' % (c['year1'], c['year2'])), ]
 
             if not c["dry_run"]:
                 if c["bundle"] == "":
                     # Submit job
-                    submit_script(scriptFile, statusFile, export, job_ids_file, dependFiles=dependencies)
+                    submit_script(scriptFile, statusFile, export, job_ids_file,
+                                  dependFiles=dependencies)
                 else:
                     print("...adding to bundle '%s'" % (c["bundle"]))
 

--- a/conda/dev.yml
+++ b/conda/dev.yml
@@ -1,0 +1,21 @@
+name: chemdyg_dev
+channels:
+  - conda-forge/label/zppy_dev
+  - conda-forge
+dependencies:
+  # Build
+  # =======================
+  - python >=3.9
+  - pip
+  - setuptools
+  # Base
+  # =================
+  - cartopy
+  - jinja2
+  - matplotlib
+  - netcdf4
+  - numpy
+  - pandas
+  - scipy
+  - xarray
+  - zppy 3.0.0rc1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = chemdyg
-version = 1.0.1
+version = 1.1.0rc1
 author = Hsiang-He Lee, Qi Tang, Michael J. Prather, Jean-Christophe Golaz, Xylar Asay-Davis
 author_email = lee1061@llnl.gov
 description = E3SM Chemistry Diagnostics Package
@@ -17,13 +17,14 @@ classifiers =
 [options]
 packages = find:
 include_package_data = True
-python_requires = >=3.8
+python_requires = >=3.9
 install_requires =
    cartopy
+   jinja2
    matplotlib
    netcdf4
    numpy
    pandas
    scipy
    xarray
-   zppy >=2.2.0
+   zppy >=3.0.0


### PR DESCRIPTION
This merge includes some function name changes required for `chemdyg` to work with the latest `zppy` (v3.0.0).

It also update the version number to 1.1.0rc1 so we can make a tag for E3SM-Unified testing.

I have also added a development environment.  `chemdyg` can be tested by running:
```
conda env create -y -n chemdyg_dev -f conda/dev.yml
conda activate chemdyg_dev
python -m pip install -e . --no-deps --no-build-isolation
```

Finally, I made some formatting changes to `main.py` to follow the [PEP8](https://peps.python.org/pep-0008/) formatting standard.  We try to have E3SM python codes follow this standard where possible.

Fixes #46 