### PR TITLE
fix unit conversion of CO and CH4 burden in the summary table

### DIFF
--- a/chemdyg/templates/chemdyg_summary_table.bash
+++ b/chemdyg/templates/chemdyg_summary_table.bash
@@ -177,34 +177,34 @@ for var in range(len(varname)):
             CIP = h0_in[varname[var]+'_2DCIP'+layer[ll]] #kg/m2/sec
             CIL = h0_in[varname[var]+'_2DCIL'+layer[ll]] #kg/m2/sec
             total_net = CIP-CIL
-            TOZ = SCO+TCO
+            TOZ = SCO+TCO #Tg
 
             MSD_total = ((MSD*area).sum(axis=1)).mean() #kg
             TDD_total = (dt*(TDD*area).sum(axis=1)).mean() #kg
             CIP_total = (dt*(CIP*area).sum(axis=1)).mean()
             CIL_total = (dt*(-CIL*area).sum(axis=1)).mean()
             NET       = (dt*((CIP-CIL)*area).sum(axis=1)).mean()
-            SCO_total = (SCO*area).sum(axis=1).mean() #kg
-            TCO_total = (TCO*area).sum(axis=1).mean() #kg
-            TOZ_total = (TOZ*area).sum(axis=1).mean() #kg
+            SCO_total = (SCO*area).sum(axis=1).mean() #Tg
+            TCO_total = (TCO*area).sum(axis=1).mean() #Tg
+            TOZ_total = (TOZ*area).sum(axis=1).mean() #Tg
             # NH
             MSD_NH = ((MSD*NH).sum(axis=1)).mean() #kg
             TDD_NH = (dt*(TDD*NH).sum(axis=1)).mean() #kg
             CIP_NH = (dt*(CIP*NH).sum(axis=1)).mean()
             CIL_NH = (dt*(-CIL*NH).sum(axis=1)).mean()
             NET_NH = (dt*((CIP-CIL)*NH).sum(axis=1)).mean()
-            SCO_NH = (SCO*NH).sum(axis=1).mean() #kg
-            TCO_NH = (TCO*NH).sum(axis=1).mean() #kg
-            TOZ_NH = (TOZ*NH).sum(axis=1).mean() #kg
+            SCO_NH = (SCO*NH).sum(axis=1).mean() #Tg
+            TCO_NH = (TCO*NH).sum(axis=1).mean() #Tg
+            TOZ_NH = (TOZ*NH).sum(axis=1).mean() #Tg
             # SH
             MSD_SH = ((MSD*SH).sum(axis=1)).mean() #kg
             TDD_SH = (dt*(TDD*SH).sum(axis=1)).mean() #kg
             CIP_SH = (dt*(CIP*SH).sum(axis=1)).mean()
             CIL_SH = (dt*(-CIL*SH).sum(axis=1)).mean()
             NET_SH = (dt*((CIP-CIL)*SH).sum(axis=1)).mean()
-            SCO_SH = (SCO*SH).sum(axis=1).mean() #kg
-            TCO_SH = (TCO*SH).sum(axis=1).mean() #kg
-            TOZ_SH = (TOZ*SH).sum(axis=1).mean() #kg
+            SCO_SH = (SCO*SH).sum(axis=1).mean() #Tg
+            TCO_SH = (TCO*SH).sum(axis=1).mean() #Tg
+            TOZ_SH = (TOZ*SH).sum(axis=1).mean() #Tg
             # calculate STE
             for i in range(len(time)):
                 MSDt = h1_in[varname[var]+'_2DMSD_trop'][i,:] #kg/m2

--- a/chemdyg/templates/chemdyg_summary_table.bash
+++ b/chemdyg/templates/chemdyg_summary_table.bash
@@ -310,9 +310,9 @@ for var in range(len(varname)):
             NET2_SH   = (dt*((CEP+CEL)*SH).sum(axis=1)).mean()
 
             line_ann = line_ann + '<pre> '+ format('CO burden (Tg)','37s')
-            line_ann = line_ann + '     '+"{0:+.3e}".format(np.array(MSD_total)*unit_covet)
-            line_ann = line_ann + '       '+"{0:+.3e}".format(np.array(MSD_NH)*unit_covet)
-            line_ann = line_ann + '       '+"{0:+.3e}".format(np.array(MSD_SH)*unit_covet)+'</pre>'
+            line_ann = line_ann + '     '+"{0:+.3e}".format(np.array(MSD_total)*1.e-9)
+            line_ann = line_ann + '       '+"{0:+.3e}".format(np.array(MSD_NH)*1.e-9)
+            line_ann = line_ann + '       '+"{0:+.3e}".format(np.array(MSD_SH)*1.e-9)+'</pre>'
             line_ann = line_ann + '<pre> '+ format('CO emission (Tg/yr)','37s')
             line_ann = line_ann + '     '+"{0:+.3e}".format(np.array(TDS_total)*unit_covet)
             line_ann = line_ann + '       '+"{0:+.3e}".format(np.array(TDS_NH)*unit_covet)
@@ -361,9 +361,9 @@ for var in range(len(varname)):
             CEL_SH = (dt*(CEL*SH).sum(axis=1)).mean()
 
             line_ann = line_ann + '<pre> '+ format('CH4 burden (Tg)','37s')
-            line_ann = line_ann + '     '+"{0:+.3e}".format(np.array(MSD_total)*unit_covet)
-            line_ann = line_ann + '       '+"{0:+.3e}".format(np.array(MSD_NH)*unit_covet)
-            line_ann = line_ann + '       '+"{0:+.3e}".format(np.array(MSD_SH)*unit_covet)+'</pre>'
+            line_ann = line_ann + '     '+"{0:+.3e}".format(np.array(MSD_total)*1.e-9)
+            line_ann = line_ann + '       '+"{0:+.3e}".format(np.array(MSD_NH)*1.e-9)
+            line_ann = line_ann + '       '+"{0:+.3e}".format(np.array(MSD_SH)*1.e-9)+'</pre>'
             line_ann = line_ann + '<pre> '+ format('CH4 emission (Tg/yr)','37s')
             line_ann = line_ann + '     '+"{0:+.3e}".format(np.array(TDS_total)*unit_covet)
             line_ann = line_ann + '       '+"{0:+.3e}".format(np.array(TDS_NH)*unit_covet)


### PR DESCRIPTION
unit_covet = 1.e-9*12 is the factor to convert kg/month to Tg/year, which should not be applied to burden terms, e.g., CO and CH4, which only need the factor 1.e-9 to convert from kg to Tg. This PR fix this bug.

NOx burden is likely affected by this bug too. But since it might need to consider the molecule weight of NO, NO, vs. N, the fix will be implemented in a separate PR.