### PR TITLE
Fix short name

### DIFF
--- a/chemdyg/templates/chemdyg_STE_flux_diags.bash
+++ b/chemdyg/templates/chemdyg_STE_flux_diags.bash
@@ -96,13 +96,14 @@ import os
 path = './ts/'
 pathout = './'
 
+case_name = '${case}'
 short_name = '${short}'
 startyear = ${y1}
 endyear = ${y2}
 nyears = endyear - startyear + 1
 
-filename = short_name+'.eam.h0.*.nc'
-filenameh1 = short_name+'.${eamfile}.*.nc'
+filename = case_name+'.eam.h0.*.nc'
+filenameh1 = case_name+'.${eamfile}.*.nc'
 
 varname = ["O3"]
 

--- a/chemdyg/templates/chemdyg_TOZ_eq_plot.bash
+++ b/chemdyg/templates/chemdyg_TOZ_eq_plot.bash
@@ -113,7 +113,7 @@ import pandas as pd
 import pylab
 from matplotlib.dates import DateFormatter
 
-filename = '${short}'
+filename = '${case}'
 path = './ts/'
 pathout = './'
 refer = xr.open_dataset(path+filename+'.eam.h0.${Y1}-01.nc')

--- a/chemdyg/templates/chemdyg_diags.bash
+++ b/chemdyg/templates/chemdyg_diags.bash
@@ -111,11 +111,12 @@ import pandas as pd
 path = './climo/'
 pathout = './'
 
+case_name = '${case}'
 short_name = '${short}'
 startyear = '${Y1}'
 endyear = '${Y2}'
 
-filename = short_name+'*_ANN_*.nc'
+filename = case_name+'*_ANN_*.nc'
 seasons = ['ANN','DJF','MAM','JJA','SON']
 
 varname = ["O3","OH","HO2","H2O2","CH2O","CH3O2","CH3OOH","NO","NO2","NO3","N2O5",
@@ -152,7 +153,7 @@ for ss in range(len(seasons)):
     fileout_ann = open(pathout+'chem_clim_'+seasons[ss]+'.html',"w")
     fileout_txt = open(pathout+'chem_clim_'+seasons[ss]+'.txt',"w")
 
-    h0_in = xr.open_mfdataset(path+short_name+'*'+seasons[ss]+'*.nc')
+    h0_in = xr.open_mfdataset(path+case_name+'*'+seasons[ss]+'*.nc')
 
     for var in range(len(varname)-1):
         if varname[var] in trop_list:
@@ -262,7 +263,7 @@ for ss in range(len(seasons)):
     line_ann = line_ann + '<pre> Chemistry           TDI            TIP            TIL            NET1         L2 DIFF          TRI            CIP            CIL          NET2          L2 DIFF          MPP            MPL            NET3          L2 DIFF        </pre>'
     line_ann = line_ann + '<pre>                                                                (TIP+TIL)     (TDI;NET1)                                                  (CIP+CIL)     (TDI+TRI;NET2)                                (MPP+MPL)     (TDI+TRI;NET3)   </pre>'
     fileout_ann = open(pathout+'chem_prodloss_'+seasons[ss]+'.html',"w")
-    h0_in = xr.open_mfdataset(path+short_name+'*'+seasons[ss]+'*.nc')
+    h0_in = xr.open_mfdataset(path+case_name+'*'+seasons[ss]+'*.nc')
 
     for var in range(len(varname)):
         total_layer = len(layer)-1

--- a/chemdyg/templates/chemdyg_lat_lon_plots.bash
+++ b/chemdyg/templates/chemdyg_lat_lon_plots.bash
@@ -116,11 +116,12 @@ import xarray as xr
 path = './climo/'
 pathout = './'
 
+case_name = '${case}'
 short_name = '${short}'
 startyear = '${Y1}'
 endyear = '${Y2}'
 
-filename = short_name+'_ANN_'+startyear+'01_'+endyear+'12_climo.nc'
+filename = case_name+'_ANN_'+startyear+'01_'+endyear+'12_climo.nc'
 
 file_in = xr.open_dataset(path+filename)
 

--- a/chemdyg/templates/chemdyg_nox_emis_plots.bash
+++ b/chemdyg/templates/chemdyg_nox_emis_plots.bash
@@ -115,11 +115,12 @@ import cartopy.crs as ccrs
 path = './climo/'
 pathout = './'
 
+case_name = '${case}'
 short_name = '${short}'
 startyear = '${Y1}'
 endyear = '${Y2}'
 
-filename = short_name+'_ANN_'+startyear+'01_'+endyear+'12_climo.nc'
+filename = case_name+'_ANN_'+startyear+'01_'+endyear+'12_climo.nc'
 
 file_in = xr.open_dataset(path+filename)
 

--- a/chemdyg/templates/chemdyg_o3_hole_diags.bash
+++ b/chemdyg/templates/chemdyg_o3_hole_diags.bash
@@ -113,7 +113,7 @@ import pandas as pd
 import pylab
 from matplotlib.dates import DateFormatter
 
-filename = '${short}'
+filename = '${case}'
 path = './ts/'
 pathout = './'
 

--- a/chemdyg/templates/chemdyg_pres_lat_plots.bash
+++ b/chemdyg/templates/chemdyg_pres_lat_plots.bash
@@ -118,11 +118,12 @@ from scipy import interpolate
 path = './climo/'
 pathout = './'
 
+case_name = '${case}'
 short_name = '${short}'
 startyear = '${Y1}'
 endyear = '${Y2}'
 
-filename = short_name+'_ANN_'+startyear+'01_'+endyear+'12_climo.nc'
+filename = case_name+'_ANN_'+startyear+'01_'+endyear+'12_climo.nc'
 refername = 'v2.LR.amip_0101_ANN_198501_201412_climo.nc'
 
 file_in = xr.open_dataset(path+filename)

--- a/chemdyg/templates/chemdyg_summary_table.bash
+++ b/chemdyg/templates/chemdyg_summary_table.bash
@@ -108,12 +108,13 @@ import pandas as pd
 path = './ts/'
 pathout = './'
 
+case_name = '${case}'
 short_name = '${short}'
 startyear = '${y1}'
 endyear = '${y2}'
 
-filename = short_name+'.eam.h0.*.nc'
-filenameh1 = short_name+'.${eamfile}.*.nc'
+filename = case_name+'.eam.h0.*.nc'
+filenameh1 = case_name+'.${eamfile}.*.nc'
 
 varname = ["O3","CO","CH4LNZ","NO"]
 layer = ['']

--- a/chemdyg/templates/chemdyg_temperature_eq_plot.bash
+++ b/chemdyg/templates/chemdyg_temperature_eq_plot.bash
@@ -112,11 +112,12 @@ import xarray as xr
 import pandas as pd
 import pylab
 
+casename = '${case}'
 filename = '${short}'
 path = './ts/'
 pathout = './'
-refer = xr.open_dataset(path+filename+'.eam.h0.${Y1}-01.nc')
-file_in = xr.open_mfdataset(path+filename+'.${eamfile}.*')
+refer = xr.open_dataset(path+casename+'.eam.h0.${Y1}-01.nc')
+file_in = xr.open_mfdataset(path+casename+'.${eamfile}.*')
 
 lat = file_in['lat']
 lat2 = refer['lat']

--- a/chemdyg/templates/chemdyg_ts.bash
+++ b/chemdyg/templates/chemdyg_ts.bash
@@ -109,12 +109,13 @@ import pandas as pd
 path = './'
 pathout = './'
 
+case_name = '${case}'
 short_name = '${short}'
 startyear = '${y1}'
 endyear = '${y2}'
 
-filename = short_name+'.eam.h0.*.nc'
-filenameh1 = short_name+'.${eamfile}.*.nc'
+filename = case_name+'.eam.h0.*.nc'
+filenameh1 = case_name+'.${eamfile}.*.nc'
 
 varname = ["O3","OH","HO2","H2O2","CH2O","CH3O2","CH3OOH","NO","NO2","NO3","N2O5",
            "HNO3","HO2NO2","PAN","CO","C2H6","C3H8","C2H4","ROHO2","CH3COCH3","C2H5O2",


### PR DESCRIPTION
"Short name" is designed to show the short form of case names, but it was mistakenly used to match the raw model output file names as reported in https://github.com/E3SM-Project/ChemDyg/issues/54. This PR fixed it by using the case name via "case".

Tested successfully at `/lcrc/group/e3sm/ac.qtang/E3SM_simulations/E3SMv3/tst_chemdyg/20231110.uci-linoz3.1870-2014.09142022branch.t0.master.v2_like.F20TR.chrysalis/post/scripts`.
The output is at `https://web.lcrc.anl.gov/public/e3sm/diagnostic_output/ac.qtang/E3SMv3_dev/tst_chemdyg/20231110.uci-linoz3.1870-2014.09142022branch.t0.master.v2_like.F20TR.chrysalis/e3sm_chem_diags_1990_2014/plots/`

